### PR TITLE
Added linux/mono support for legacy profile

### DIFF
--- a/Fiskaly/SDK/FiskalyHttpClient.cs
+++ b/Fiskaly/SDK/FiskalyHttpClient.cs
@@ -46,7 +46,14 @@ namespace Fiskaly
 
         private void InitializeClient() {
         #if NET40
-            this.Client = new WindowsClient();
+            if (Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                Client = new LinuxClient();
+            }
+            else
+            {
+                Client = new WindowsClient();
+            }
 
         // Non-Windows platforms are only supported through .NET Standard 2.1 at the moment
         #elif NETSTANDARD2_0


### PR DESCRIPTION
The current SDK enforces the invocation of the windows version of the abstact client. This makes it not particular useful for a linux/mono setup. This PR fixes that and will fallback to the windows version anyways.